### PR TITLE
Fix highlight language dropdown visibility

### DIFF
--- a/components/select-highligh-language.component.js
+++ b/components/select-highligh-language.component.js
@@ -2,12 +2,9 @@ import { FormControl, MenuItem, Select } from "@material-ui/core";
 import { availableLanguages } from "../constants/highlight";
 
 function SelectHighlightLanguageComponent({ language, onChange }) {
-  if (!language) {
-    return null;
-  }
   return (
     <FormControl>
-      <Select value={language} onChange={onChange}>
+      <Select value={language || ""} onChange={onChange}>
         {availableLanguages.map((lang) => (
           <MenuItem key={lang.key} value={lang.value}>
             {lang.key}


### PR DESCRIPTION
## Summary
- always render highlight language dropdown

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eaf6a098833097b2c7002c654f5d