### PR TITLE
Update Material UI for Node 18 build

### DIFF
--- a/components/available-commands.component.js
+++ b/components/available-commands.component.js
@@ -11,7 +11,9 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import SearchFieldComponent from "./search-field.component";
 import CommandGuideComponent from "./command-guide.component";
-import { Info, InfoOutlined, InfoRounded } from "@mui/icons-material";
+import Info from "@mui/icons-material/Info";
+import InfoOutlined from "@mui/icons-material/InfoOutlined";
+import InfoRounded from "@mui/icons-material/InfoRounded";
 
 async function getCommands(service) {
   const response = await axios.get(`/api/${service.name}/available-commands`, {

--- a/components/available-commands.component.js
+++ b/components/available-commands.component.js
@@ -6,12 +6,12 @@ import {
   ListItemText,
   ListSubheader,
   Typography,
-} from "@material-ui/core";
+} from "@mui/material";
 import { useEffect, useState } from "react";
 import axios from "axios";
 import SearchFieldComponent from "./search-field.component";
 import CommandGuideComponent from "./command-guide.component";
-import { Info, InfoOutlined, InfoRounded } from "@material-ui/icons";
+import { Info, InfoOutlined, InfoRounded } from "@mui/icons-material";
 
 async function getCommands(service) {
   const response = await axios.get(`/api/${service.name}/available-commands`, {

--- a/components/close-control.component.js
+++ b/components/close-control.component.js
@@ -1,5 +1,5 @@
-import { FormControlLabel, IconButton } from "@material-ui/core";
-import { Close } from "@material-ui/icons";
+import { FormControlLabel, IconButton } from "@mui/material";
+import Close from "@mui/icons-material/Close";
 
 function CloseControlComponent(props) {
   return (

--- a/components/command-guide.component.js
+++ b/components/command-guide.component.js
@@ -5,7 +5,7 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-} from "@material-ui/core";
+} from "@mui/material";
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 

--- a/components/command.component.js
+++ b/components/command.component.js
@@ -7,9 +7,9 @@ import {
   LinearProgress,
   TextField,
   Typography,
-} from "@material-ui/core";
-import { ExpandMore } from "@material-ui/icons";
-import { Alert } from "@material-ui/lab";
+} from "@mui/material";
+import ExpandMore from "@mui/icons-material/ExpandMore";
+import Alert from "@mui/material/Alert";
 import axios from "axios";
 import React, { useEffect, useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";

--- a/components/copy-control.component.js
+++ b/components/copy-control.component.js
@@ -1,5 +1,5 @@
-import { FormControlLabel, IconButton } from "@material-ui/core";
-import { FileCopy } from "@material-ui/icons";
+import { FormControlLabel, IconButton } from "@mui/material";
+import FileCopy from "@mui/icons-material/FileCopy";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 
 function CopyControlComponent({ textToCopy }) {

--- a/components/navbar.component.js
+++ b/components/navbar.component.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { AppBar, Toolbar, Typography } from "@material-ui/core";
+import { AppBar, Toolbar, Typography } from "@mui/material";
 
 function NavbarComponent() {
   return (

--- a/components/search-field.component.js
+++ b/components/search-field.component.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { InputAdornment, TextField } from "@material-ui/core";
-import { Search } from "@material-ui/icons";
+import { InputAdornment, TextField } from "@mui/material";
+import Search from "@mui/icons-material/Search";
 
 function SearchFieldComponent(props) {
   return (

--- a/components/select-highligh-language.component.js
+++ b/components/select-highligh-language.component.js
@@ -1,4 +1,4 @@
-import { FormControl, MenuItem, Select } from "@material-ui/core";
+import { FormControl, MenuItem, Select } from "@mui/material";
 import { availableLanguages } from "../constants/highlight";
 
 function SelectHighlightLanguageComponent({ language, onChange }) {

--- a/components/sidebar.component.js
+++ b/components/sidebar.component.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { List, ListItem, Grid, LinearProgress } from "@material-ui/core";
+import { List, ListItem, Grid, LinearProgress } from "@mui/material";
 import SidebarMenuItemComponent from "./sidebar/menuitem.component";
 import axios from "axios";
 import SearchFieldComponent from "./search-field.component";

--- a/components/sidebar/menuitem.component.js
+++ b/components/sidebar/menuitem.component.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ListItem, ListItemText, Typography } from "@material-ui/core";
+import { ListItem, ListItemText, Typography } from "@mui/material";
 
 function SidebarMenuItemComponent({ service, setService }) {
   return (

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@mui/material": "^5.15.0",
     "@mui/icons-material": "^5.15.0",
     "@mui/lab": "^5.0.0-alpha.125",
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
     "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.5",
     "next": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
   "dependencies": {
     "@cronitorio/cronitor-rum-nextjs": "^0.3.0",
     "@fontsource/roboto": "^4.2.0",
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.57",
-    "@material-ui/styles": "^4.11.3",
+    "@mui/material": "^5.15.0",
+    "@mui/icons-material": "^5.15.0",
+    "@mui/lab": "^5.0.0-alpha.125",
     "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.5",
     "next": "^13.3.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,6 @@
 import "@fontsource/roboto";
 import "../styles/globals.css";
-import { ThemeProvider, CssBaseline } from "@material-ui/core";
+import { ThemeProvider, CssBaseline } from "@mui/material";
 import { theme } from "../styles/theme";
 import { useCronitor } from "@cronitorio/cronitor-rum-nextjs";
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { Grid } from "@material-ui/core";
+import { Grid } from "@mui/material";
 import Head from "next/head";
 import { useState } from "react";
 import AvailableCommandsComponent from "../components/available-commands.component";

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -1,4 +1,4 @@
-import { createTheme } from "@material-ui/core/styles";
+import { createTheme } from "@mui/material/styles";
 
 export const theme = createTheme({
   palette: {
@@ -10,24 +10,30 @@ export const theme = createTheme({
       main: "#FF9900",
     },
   },
-  overrides: {
+  components: {
     MuiAppBar: {
-      root: {
-        boxShadow: "none",
+      styleOverrides: {
+        root: {
+          boxShadow: "none",
+        },
       },
     },
     MuiButton: {
-      contained: {
-        borderRadius: 0,
-        boxShadow: "none",
-      },
-      containedSecondary: {
-        color: "#FFFFFF",
+      styleOverrides: {
+        contained: {
+          borderRadius: 0,
+          boxShadow: "none",
+        },
+        containedSecondary: {
+          color: "#FFFFFF",
+        },
       },
     },
     MuiAccordion: {
-      root: {
-        boxShadow: "none",
+      styleOverrides: {
+        root: {
+          boxShadow: "none",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- update dependencies to use MUI v5 instead of deprecated material-ui v4
- migrate imports and theme customization to the new MUI packages

## Testing
- `npm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845eeec18ac8330b7d660137349f529